### PR TITLE
Do not create pre-release versions from create-release script

### DIFF
--- a/scripts/create-latest-release.sh
+++ b/scripts/create-latest-release.sh
@@ -2,9 +2,13 @@
 
 set -euo pipefail
 
-KUBEVIRT_VERSION=$(curl --fail -s https://api.github.com/repos/kubevirt/kubevirt/releases | jq -r '.[].tag_name' | sort -rV | head -1 | xargs)
+KUBEVIRT_RELEASE_VERSION=$(
+    curl --fail -s https://api.github.com/repos/kubevirt/kubevirt/releases \
+        | jq -r '(.[].tag_name | select( test("-(rc|alpha|beta)") | not ) )' \
+        | sort -rV | head -1 | xargs
+)
 
-[ -z "$KUBEVIRT_VERSION" ] && (echo "Failed to retrieve latest KubeVirt version!" ; exit 1)
+[ -z "$KUBEVIRT_RELEASE_VERSION" ] && (echo "Failed to retrieve latest KubeVirt version!" ; exit 1)
 
 
 # /repos/:owner/:repo/releases/tags/:tag
@@ -12,18 +16,18 @@ KUBEVIRT_VERSION=$(curl --fail -s https://api.github.com/repos/kubevirt/kubevirt
 set +e
 release=$(
     curl --silent --fail \
-        "https://api.github.com/repos/kubevirt/kubectl-virt-plugin/releases/tags/$KUBEVIRT_VERSION" \
+        "https://api.github.com/repos/kubevirt/kubectl-virt-plugin/releases/tags/$KUBEVIRT_RELEASE_VERSION" \
         -H 'Content-Type: text/json; charset=utf-8' 2>&1
 )
 result=$?
 set -e
 
 if [ $result -eq 0 ]; then
-    echo "Release $KUBEVIRT_VERSION already exists!"
+    echo "Release $KUBEVIRT_RELEASE_VERSION already exists!"
     exit 0
 fi
 
-echo "Preparing packages for release $KUBEVIRT_VERSION..."
+echo "Preparing packages for release $KUBEVIRT_RELEASE_VERSION..."
 
 # shellcheck source=scripts/functions.sh
-"$(dirname "${BASH_SOURCE[0]}")/create-release.sh" "$KUBEVIRT_VERSION"
+"$(dirname "${BASH_SOURCE[0]}")/create-release.sh" "$KUBEVIRT_RELEASE_VERSION"


### PR DESCRIPTION
The fetching of release versions included all versions, i.e. -rc
and -alpha also. These are now excluded, so that only packages
for release versions will be created.
