### PR TITLE
Make validation of krew manifest work, rely on GIT_ASKPASS

### DIFF
--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -7,6 +7,23 @@ RUN apt-get update \
         python3-pkg-resources \
         yamllint
 
+# install kubectl
+RUN kubectl_version=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt) && \
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$kubectl_version/bin/linux/amd64/kubectl && \
+    rm -f /google-cloud-sdk/bin/kubectl && \
+    mv kubectl /google-cloud-sdk/bin/ && \
+    chmod +x /google-cloud-sdk/bin/kubectl
+
+# install krew
+RUN set -x && \
+    curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/download/v0.3.3/krew.{tar.gz,yaml}" && \
+    tar zxvf krew.tar.gz && \
+    mv krew-linux_amd64 "/google-cloud-sdk/bin/kubectl-krew" && \
+    chmod +x "/google-cloud-sdk/bin/kubectl-krew"
+
+RUN kubectl --client=true version && \
+    kubectl krew version
+
 ENV GIMME_GO_VERSION=1.13.14
 
 RUN mkdir -p /gimme && curl -sL \

--- a/scripts/functions
+++ b/scripts/functions
@@ -246,7 +246,7 @@ function validate_krew_manifest() {
     local version
     version="$1"
 
-    if ! command -V validate-krew-manifest; then
+    if [ ! command -V validate-krew-manifest ] -o [ ! command -V kubectl ] ; then
         cat <<EOF
 Will not be able to validate manifest file, validate-krew-manifest is missing
 
@@ -271,8 +271,8 @@ function create_pull_request() {
         git clone "https://$origin"
 
         cd "$repo_dir" || (echo "Failed to cd into $repo_dir"; exit 1)
-        git config user.email "daniel.hiller.1972@gmail.com"
-        git config user.name "Daniel Hiller"
+        git config user.name "$GITHUB_USER"
+        git config user.email "$GITHUB_EMAIL"
 
         fork='github.com/kubevirt/krew-index.git'
         git remote add fork "https://$fork"
@@ -307,13 +307,5 @@ EOF
 }
 
 function get_github_auth() {
-    echo "$(get_github_username):$(get_github_token)"
-}
-
-function get_github_username() {
-    echo "$GH_KUBECTL_VIRT_PLUGIN_USERNAME"
-}
-
-function get_github_token() {
-    echo "$GH_KUBECTL_VIRT_PLUGIN_TOKEN"
+    echo "$GITHUB_USER:$(bash "$GIT_ASKPASS")"
 }


### PR DESCRIPTION
We remove the token stuff to entirely switch to GIT_ASKPASS.

Also we replace kubectl version in builder as it doesn't support plugins and install krew to be able to test the install.