### PR TITLE
Build image on top of kubevirtci/bootstrap

### DIFF
--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+FROM kubevirtci/bootstrap:v20201119-a5880e0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends --no-upgrade \


### PR DESCRIPTION
Similar to https://github.com/kubevirt/project-infra/pull/750, this will allow us to use the in-cluster docker proxy. 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>