### PR TITLE
Move danielBelenky to emeritus approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,12 +3,12 @@ filters:
     reviewers:
       - rmohr
       - stu-gott
-      - danielBelenky
       - dhiller
       - fgimenez
     approvers:
       - rmohr
       - stu-gott
-      - danielBelenky
       - dhiller
       - fgimenez
+    emeritus_approvers:
+      - danielBelenky


### PR DESCRIPTION
In order to avoid assigning reviews and honor the former approver state to the now inactive member.