### PR TITLE
README/OWNERS: update release creation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,17 +80,36 @@ After we have installed the virt plugin we can use it:
 
 ## Creating krew packages after a new KubeVirt release 
 
-Example: prepare a kubectl krew release for a new release
+**Note: a [prow job](https://github.com/kubevirt/project-infra/blob/cd56918c29690a1cda96d91a781b948f105c1dd6/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-periodics.yaml#L2) periodically executes the below script**
 
-### `./scripts/create-latest-release.sh`
+### Latest release
 
-Just execute `./scripts/create-latest-release.sh` from the base directory. The script will create packages, a yaml file, store them in a new release in GitHub repo and finally create a PR against the `krew-index` repo in draft mode.
+To manually prepare a kubectl krew release for a new release
+just execute `./scripts/create-latest-release.sh` from the base directory. The script will create packages and store them in a new release in GitHub repo.
 
-    $ ./scripts/create-latest-release.sh
-    Downloading binaries:
-    ...
-    
-    Creating pull request:
-    ...
+```bash
+$ ./scripts/create-latest-release.sh
+```
+
+Output will be
+```
+Downloading binaries:
+...
+
+Creating pull request:
+...
+```
+
+Creating the release will trigger [a GitHub action](.github/workflows/krew-release-bot.yaml) that then will create a PR against the [`krew-index`](https://github.com/kubernetes-sigs/krew-index) ([example](https://github.com/kubernetes-sigs/krew-index/pull/3677)).
     
 After the script has finished successfully you should see a URL where you will find the created PR, which then just needs to be confirmed that it is reviewable.
+
+### Specific release
+
+Running `./scripts/create-release.sh` with a specific version will generate the release packages and create a release in GitHub.
+
+```bash
+./scripts/create-release.sh v1.2.0
+```
+
+The triggered GitHub actions will then create a PR as described above.

--- a/README.md
+++ b/README.md
@@ -101,8 +101,6 @@ Creating pull request:
 ```
 
 Creating the release will trigger [a GitHub action](.github/workflows/krew-release-bot.yaml) that then will create a PR against the [`krew-index`](https://github.com/kubernetes-sigs/krew-index) ([example](https://github.com/kubernetes-sigs/krew-index/pull/3677)).
-    
-After the script has finished successfully you should see a URL where you will find the created PR, which then just needs to be confirmed that it is reviewable.
 
 ### Specific release
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Updates the README file section for how to manually create a release.
Also adds a note that there's a periodic job that executes the release
creation.

~Also moves @rmohr and @fgimenez to emeritus approvers.~ This has been done in another PR now.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @stu-gott @acardace

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
